### PR TITLE
Fix preview highlighting and race condition with nvim 0.12.x

### DIFF
--- a/fnl/snap/init.fnl
+++ b/fnl/snap/init.fnl
@@ -616,9 +616,10 @@
      : on-update}))
 
   ;; Feed the initial filer to the input
-  (when (not= initial-filter "")
+  (if (not= initial-filter "")
     ;; We do it this way because prompts are broken in nvim
-    (vim.api.nvim_feedkeys initial-filter :n false))
+    (vim.api.nvim_feedkeys initial-filter :n false)
+    (vim.schedule (fn [] (on-update ""))))
 
   nil)
 

--- a/fnl/snap/preview/common/syntax.fnl
+++ b/fnl/snap/preview/common/syntax.fnl
@@ -1,25 +1,12 @@
 (let [snap-io (require :snap.common.io)]
   (fn [file-name bufnr]
-    (local has-treesitter (pcall require :nvim-treesitter))
-    (local (_ highlight) (pcall require :nvim-treesitter.highlight))
-    (local (_ parsers) (pcall require :nvim-treesitter.parsers))
     (local fake-path (.. (vim.fn.tempname) "/" file-name))
-    (vim.api.nvim_buf_set_name bufnr fake-path)
-    (vim.api.nvim_buf_call bufnr (fn []
-      ;; Use the fake path to enable ftdetection
-      (local eventignore (vim.api.nvim_get_option "eventignore"))
-      (vim.api.nvim_set_option "eventignore" "FileType")
-      (vim.api.nvim_command "filetype detect")
-      (vim.api.nvim_set_option "eventignore" eventignore)))
-    ;; Add syntax highlighting
-    (local filetype (vim.api.nvim_buf_get_option bufnr "filetype"))
-    (when
-      (not= filetype "")
-      (if
-        has-treesitter
-        (let [lang (parsers.ft_to_lang filetype)]
-          (if
-            (parsers.has_parser lang)
-            (highlight.attach bufnr lang)
-            (vim.api.nvim_buf_set_option bufnr "syntax" filetype)))
-        (vim.api.nvim_buf_set_option bufnr "syntax" filetype)))))
+    (pcall vim.api.nvim_buf_set_name bufnr fake-path)
+    (local filetype (or (vim.filetype.match {:filename file-name}) ""))
+
+    (when (not= filetype "")
+      (vim.api.nvim_set_option_value "filetype" filetype {:buf bufnr})
+      (local lang (or (vim.treesitter.language.get_lang filetype) filetype))
+      (local (ts-ok? _) (pcall vim.treesitter.start bufnr lang))
+      (when (not ts-ok?)
+        (vim.api.nvim_set_option_value "syntax" filetype {:buf bufnr})))))

--- a/fnl/snap/view/input.fnl
+++ b/fnl/snap/view/input.fnl
@@ -82,7 +82,9 @@
       (config.on-select-all-toggle))
 
     (fn on_lines []
-      (config.on-update (get-filter))
+      (vim.schedule (fn []
+        (when (not exited)
+          (config.on-update (get-filter)))))
       nil)
 
     (fn on_detach [] nil)

--- a/lua/snap/init.lua
+++ b/lua/snap/init.lua
@@ -755,16 +755,20 @@ local function run(config1)
   if (initial_filter ~= "") then
     vim.api.nvim_feedkeys(initial_filter, "n", false)
   else
+    local function _108_()
+      return on_update("")
+    end
+    vim.schedule(_108_)
   end
   return nil
 end
 _2amodule_2a["run"] = run
 local function create(config1, defaults)
   assert((type(config1) == "function"), "Config must be a function")
-  local function _109_()
+  local function _110_()
     return run(tbl.merge((defaults or {}), config1()))
   end
-  return _109_
+  return _110_
 end
 _2amodule_2a["create"] = create
 return _2amodule_2a

--- a/lua/snap/preview/common/syntax.lua
+++ b/lua/snap/preview/common/syntax.lua
@@ -1,29 +1,17 @@
 local _2afile_2a = "fnl/snap/preview/common/syntax.fnl"
 local snap_io = require("snap.common.io")
 local function _1_(file_name, bufnr)
-  local has_treesitter = pcall(require, "nvim-treesitter")
-  local _, highlight = pcall(require, "nvim-treesitter.highlight")
-  local _0, parsers = pcall(require, "nvim-treesitter.parsers")
   local fake_path = (vim.fn.tempname() .. "/" .. file_name)
-  vim.api.nvim_buf_set_name(bufnr, fake_path)
-  local function _2_()
-    local eventignore = vim.api.nvim_get_option("eventignore")
-    vim.api.nvim_set_option("eventignore", "FileType")
-    vim.api.nvim_command("filetype detect")
-    return vim.api.nvim_set_option("eventignore", eventignore)
-  end
-  vim.api.nvim_buf_call(bufnr, _2_)
-  local filetype = vim.api.nvim_buf_get_option(bufnr, "filetype")
+  pcall(vim.api.nvim_buf_set_name, bufnr, fake_path)
+  local filetype = (vim.filetype.match({filename = file_name}) or "")
   if (filetype ~= "") then
-    if has_treesitter then
-      local lang = parsers.ft_to_lang(filetype)
-      if parsers.has_parser(lang) then
-        return highlight.attach(bufnr, lang)
-      else
-        return vim.api.nvim_buf_set_option(bufnr, "syntax", filetype)
-      end
+    vim.api.nvim_set_option_value("filetype", filetype, {buf = bufnr})
+    local lang = (vim.treesitter.language.get_lang(filetype) or filetype)
+    local ts_ok_3f, _ = pcall(vim.treesitter.start, bufnr, lang)
+    if not ts_ok_3f then
+      return vim.api.nvim_set_option_value("syntax", filetype, {buf = bufnr})
     else
-      return vim.api.nvim_buf_set_option(bufnr, "syntax", filetype)
+      return nil
     end
   else
     return nil

--- a/lua/snap/view/input.lua
+++ b/lua/snap/view/input.lua
@@ -91,7 +91,14 @@ local function create(config)
     return config["on-select-all-toggle"]()
   end
   local function on_lines()
-    config["on-update"](get_filter())
+    local function _9_()
+      if not exited then
+        return config["on-update"](get_filter())
+      else
+        return nil
+      end
+    end
+    vim.schedule(_9_)
     return nil
   end
   local function on_detach()
@@ -99,18 +106,18 @@ local function create(config)
   end
   register["buf-map"](bufnr, {"n", "i"}, mappings0.next, on_next)
   register["buf-map"](bufnr, {"n", "i"}, mappings0.enter, on_enter)
-  local function _9_(...)
+  local function _11_(...)
     return on_enter("split", ...)
   end
-  register["buf-map"](bufnr, {"n", "i"}, mappings0["enter-split"], _9_)
-  local function _10_(...)
+  register["buf-map"](bufnr, {"n", "i"}, mappings0["enter-split"], _11_)
+  local function _12_(...)
     return on_enter("vsplit", ...)
   end
-  register["buf-map"](bufnr, {"n", "i"}, mappings0["enter-vsplit"], _10_)
-  local function _11_(...)
+  register["buf-map"](bufnr, {"n", "i"}, mappings0["enter-vsplit"], _12_)
+  local function _13_(...)
     return on_enter("tab", ...)
   end
-  register["buf-map"](bufnr, {"n", "i"}, mappings0["enter-tab"], _11_)
+  register["buf-map"](bufnr, {"n", "i"}, mappings0["enter-tab"], _13_)
   register["buf-map"](bufnr, {"n", "i"}, mappings0.exit, on_exit)
   register["buf-map"](bufnr, {"n", "i"}, mappings0.select, on_tab)
   register["buf-map"](bufnr, {"n", "i"}, mappings0.unselect, on_shifttab)
@@ -148,10 +155,10 @@ local function create(config)
     end
   end
   local view = {update = update, delete = delete, bufnr = bufnr, winnr = winnr, width = layout_config.width, height = layout_config.height}
-  local function _15_()
+  local function _17_()
     return view:update()
   end
-  vim.api.nvim_create_autocmd("VimResized", {group = group, callback = _15_})
+  vim.api.nvim_create_autocmd("VimResized", {group = group, callback = _17_})
   return view
 end
 _2amodule_2a["create"] = create


### PR DESCRIPTION
Treesitter's `parsers.ft_to_lang` API has been removed, and we now need to use first-party apis for this task.

There has been a change in render order and we now need to schedule the listing of files. When we don't do this the file list is initially empty until a character is entered, then when clearing all characters all files are listed.

These changes have been tested with neovim v0.12.1